### PR TITLE
Avoid git-switch for better backwards compatibility

### DIFF
--- a/src/patch
+++ b/src/patch
@@ -138,7 +138,9 @@ echo "*             STAGING              *"
 echo "************************************"
 echo ""
 # Create a blank branch to work on
-git switch --orphan tatter/scratch
+#git switch --orphan tatter/scratch
+git checkout --orphan tatter/scratch
+git rm -rf .
 
 # Bring over just what we need to recreate the framework
 git checkout "$BASE" -- .gitignore composer.*
@@ -183,7 +185,8 @@ git commit -m "Patch framework" --no-verify
 rm composer.*
 
 # Create the new branch from base
-git switch -c tatter/patches "$BASE"
+#git switch -c tatter/patches "$BASE"
+git checkout -b tatter/patches "$BASE"
 
 # Restore the original state of vendor/
 composer install --no-scripts > /dev/null

--- a/src/patch
+++ b/src/patch
@@ -138,7 +138,6 @@ echo "*             STAGING              *"
 echo "************************************"
 echo ""
 # Create a blank branch to work on
-#git switch --orphan tatter/scratch
 git checkout --orphan tatter/scratch
 git rm -rf .
 
@@ -185,7 +184,6 @@ git commit -m "Patch framework" --no-verify
 rm composer.*
 
 # Create the new branch from base
-#git switch -c tatter/patches "$BASE"
 git checkout -b tatter/patches "$BASE"
 
 # Restore the original state of vendor/


### PR DESCRIPTION
Replace `git-switch` commands with `git-checkout` equivalents for git < 2.23 compatibility 