### PR TITLE
feat: add git global config in arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Most of the time the simple script is what you will want, but `patch` takes a fe
 to alter the behavior of the patch process. Arguments that take a "commit-ish" can use anything
 Git recognizes (branch, hash, tag, reference, revision, etc).
 
-To ensure patches work correctly in a Docker container, you may need to manually set the `user.email` and `user.name` values using the `-e` and `-n` flags respectively. This is necessary because Docker containers are often not preconfigured for Git.
+To ensure patches work correctly in a Docker container, you may need to set the `user.email` and `user.name` values manually using the `-e` and `-n` flags respectively. This is necessary because Docker containers are often not preconfigured for Git.
 
 #### Help (-h)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Most of the time the simple script is what you will want, but `patch` takes a fe
 to alter the behavior of the patch process. Arguments that take a "commit-ish" can use anything
 Git recognizes (branch, hash, tag, reference, revision, etc).
 
+To ensure patches work correctly in a Docker container, you may need to manually set the `user.email` and `user.name` values using the `-e` and `-n` flags respectively. This is necessary because Docker containers are often not preconfigured for Git.
+
 #### Help (-h)
 
 Displays the latest command help:
@@ -66,6 +68,8 @@ Options:
   -h             Help. Show this help message and exit
   -c commit-ish  Alternate version to consider "current" (rarely needed).
   -v commit-ish  Version to use for patching. Defaults to the latest.
+  -e             Git global user.email.
+  -n             Git global user.name.
 ```
 
 #### Version (-v <commit-ish>)

--- a/src/patch
+++ b/src/patch
@@ -20,6 +20,8 @@ Options:
   -h             Help. Show this help message and exit
   -c commit-ish  Alternate version to consider "current" (rarely needed).
   -v commit-ish  Version to use for patching. Defaults to the latest.
+  -e             Git global user.email.
+  -n             Git global user.name.
 
 Examples:
   Patch the current installed repo up to the latest available.
@@ -35,7 +37,7 @@ EOT
 CURRENT_VERSION=""
 TARGET_VERSION=""
 
-while getopts "hv:c:" OPT; do
+while getopts "hv:c:e:n:" OPT; do
 	case ${OPT} in
 		h)	## -h help
 			show_help
@@ -47,6 +49,12 @@ while getopts "hv:c:" OPT; do
 		v)	## -c <target version>
 			TARGET_VERSION=${OPTARG}
 			;;
+        e)  ## -e <git user.email>
+            GIT_USER_EMAIL=${OPTARG}
+            ;;
+        n)  ## -n <git user.name>
+            GIT_USER_NAME=${OPTARG}
+            ;;
 	esac
 done
 
@@ -76,6 +84,12 @@ try()
 # Verify executables
 git --version
 try $? "Git must be installed."
+
+# When using patches in a Docker container, it is necessary to manually set the user.email and user.name values
+if [[ -n "$GIT_USER_EMAIL" && -n "$GIT_USER_NAME" ]]; then
+    git config --global user.email "$GIT_USER_EMAIL";
+    git config --global user.name "$GIT_USER_NAME";
+fi
 
 composer --version
 try $? "Composer must be installed."

--- a/src/patch
+++ b/src/patch
@@ -85,7 +85,7 @@ try()
 git --version
 try $? "Git must be installed."
 
-# When using patches in a Docker container, it is necessary to manually set the user.email and user.name values
+# When using patches in a Docker container, it is necessary to set the user.email and user.name values manually
 if [[ -n "$GIT_USER_EMAIL" && -n "$GIT_USER_NAME" ]]; then
     git config --global user.email "$GIT_USER_EMAIL";
     git config --global user.name "$GIT_USER_NAME";


### PR DESCRIPTION
@MGatner To ensure patches work correctly in a Docker container, we may need to manually set the `user.email` and `user.name` values using the `-e` and `-n` flags respectively. This is necessary because Docker containers are often not preconfigured for Git and then patches fails because of missing configuration. This PR will fix closed issue https://github.com/tattersoftware/codeigniter4-patches/issues/23. 