### PR TITLE
fix: add composer error check

### DIFF
--- a/src/patch
+++ b/src/patch
@@ -176,12 +176,15 @@ git reset composer.*
 git commit -m "Stage framework" --no-verify > /dev/null
 
 # Check for a specific requested version
+set +e
 if [ "$TARGET_VERSION" ]; then
 	OUTPUT=$(composer require --no-scripts --with-all-dependencies "$PACKAGE" "$TARGET_VERSION" 2>&1)
 # Otherwise get the latest
 else
 	OUTPUT=$(composer update --no-scripts --with-all-dependencies "$PACKAGE" 2>&1)
 fi
+try $? "Unable to checkout $PACKAGE\n$OUTPUT"
+set -e
 
 for LINE in "$OUTPUT"; do
 	echo "$LINE\n"


### PR DESCRIPTION
Before:
There is no error. We don't know what happened.
```console
************************************
*             STAGING              *
************************************

Switched to a new branch 'tatter/scratch'
rm '.editorconfig'
...
rm 'writable/uploads/index.html'
$
```
After:
```console
************************************
*             STAGING              *
************************************

Switched to a new branch 'tatter/scratch'
rm '.editorconfig'
...
rm 'writable/uploads/index.html'
ERROR 2: Unable to checkout codeigniter4/codeigniter4
Updating dependencies Your requirements could not be resolved to an installable set of packages. Problem 1 - symfony/service-contracts v1.1.2 requires php ^7.1.3 -> your php version (8.2.16) does not satisfy that requirement. - vimeo/psalm 5.15.0 requires symfony/console ^4.1.6 || ^5.0 || ^6.0 -> satisfiable by symfony/console[v5.4.28]. - codeigniter4/devkit v1.1.2 requires vimeo/psalm ^5.0 -> satisfiable by vimeo/psalm[5.15.0]. - symfony/console v5.4.28 requires symfony/service-contracts ^1.1|^2|^3 -> satisfiable by symfony/service-contracts[v1.1.2]. - codeigniter4/devkit is locked to version v1.1.2 and an update of this package was not requested.
```